### PR TITLE
network: avoid DHCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,11 @@ Export an inventory in the Ansible format.
 
 List the distro images that can be used. Its output is compatible with `vl up`.
 You can initialize a new configuration with: `vl distro > virt-lightning.yaml`.
+
+### Performance profiling
+
+```shell
+time vl up
+vl ansible_inventory > inventory
+ansible all -m shell -a "systemd-analyze blame|head -n 5" -i inventory
+```

--- a/images/distros/centos-7
+++ b/images/distros/centos-7
@@ -3,5 +3,5 @@ IMAGE_NAME=centos-7
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --update --selinux-relabel
+        --network --update --install NetworkManager --run-command 'systemctl enable NetworkManager' --selinux-relabel
 }

--- a/images/distros/debian-9
+++ b/images/distros/debian-9
@@ -3,5 +3,7 @@ DOWNLOAD_URL=https://cdimage.debian.org/cdimage/openstack/current-9/${IMAGE_NAME
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --install qemu-guest-agent
+        --network --install qemu-guest-agent --run-command 'echo "auto eth0
+allow-hotplug eth0
+source /etc/network/interfaces.d/*" > /etc/network/interfaces'
 }

--- a/images/distros/fedora-29
+++ b/images/distros/fedora-29
@@ -3,8 +3,7 @@ DOWNLOAD_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/${FEDO
 IMAGE_NAME=fedora-${FEDORA_VERSION}
 
 function prepare {
-    network-scripts because of https://bugs.launchpad.net/cloud-init/+bug/1799301
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --update --install qemu-guest-agent,network-scripts,python \
+        --network --update --install qemu-guest-agent,python \
         --run-command 'systemctl enable qemu-guest-agent' --selinux-relabel
 }

--- a/images/distros/rhel-7.4
+++ b/images/distros/rhel-7.4
@@ -4,5 +4,5 @@ DOWNLOAD_URL=http://download-node-02.eng.bos.redhat.com/released/RHEL-7/${RHEL_V
 IMAGE_NAME=rhel-${RHEL_VERSION}
 
 function prepare {
-    true
+    virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 --run-command 'rm /etc/sysconfig/network-scripts/ifcfg-eth0'
 }

--- a/images/distros/rhel-7.5
+++ b/images/distros/rhel-7.5
@@ -4,5 +4,5 @@ DOWNLOAD_URL=http://download-node-02.eng.bos.redhat.com/released/RHEL-7/${RHEL_V
 IMAGE_NAME=rhel-${RHEL_VERSION}
 
 function prepare {
-    true
+    virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 --run-command 'rm /etc/sysconfig/network-scripts/ifcfg-eth0'
 }

--- a/images/distros/rhel-7.6
+++ b/images/distros/rhel-7.6
@@ -4,5 +4,5 @@ DOWNLOAD_URL=http://download-node-02.eng.bos.redhat.com/released/RHEL-7/${RHEL_V
 IMAGE_NAME=rhel-${RHEL_VERSION}
 
 function prepare {
-    true
+    virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 --run-command 'rm /etc/sysconfig/network-scripts/ifcfg-eth0'
 }

--- a/virt_lightning/templates.py
+++ b/virt_lightning/templates.py
@@ -113,3 +113,12 @@ BRIDGE_XML = """
   <address type='pci'/>
 </interface>
 """
+
+# TODO
+CLOUD_INIT_ENI = """network-interfaces: |
+   iface eth0 inet static
+   address {ipv4}
+   network 192.168.122.0
+   netmask 255.255.255.0
+   gateway {gateway}
+ """


### PR DESCRIPTION
DHCP slow thing down a lot (=~15s in a 9 nodes env). We this patch, the 
nodes network configuration is static.
    
The static IP addresses are recorded in the domain XMLs, this way, we
can do quickly list the IP already in use, even if the domain are not 
running.
    
Also:
- Centos-7: enable NetworkManager to be consistent with the RHEL-7
  images
- Adjust the default configuration of the images to prevent any DHCP
  auto-configuration
    
Others:
- do not call `systemctl mask cloud-init`, this was breaking cloud-init
  at last in one environment.
- fix a little performance issue with the SSH ping