### PR TITLE
do not try to reach agent on inactive domain

### DIFF
--- a/virt_lightning/__init__.py
+++ b/virt_lightning/__init__.py
@@ -391,6 +391,8 @@ class LibvirtDomain:
         self.dom.create()
 
     def get_ipv4(self):
+        if not self.dom.isActive():
+            return
         try:
             ifaces = self.dom.interfaceAddresses(
                 libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT, 0


### PR DESCRIPTION
libvirt will raise an exception if the VM is not active and we try to access
the agent.