### PR TITLE
avoid domain with no name

### DIFF
--- a/virt_lightning/__init__.py
+++ b/virt_lightning/__init__.py
@@ -58,14 +58,18 @@ class LibvirtHypervisor:
         self.wait_for = []
         self.kvm_binary = self.find_kvm_binary()
 
-    def create_domain(self):
+    def create_domain(self, name=None, distro=None):
+        if not name:
+            name = uuid.uuid4().hex[0:10]
         root = ET.fromstring(DOMAIN_XML)
         e = root.find("./name")
-        e.text = uuid.uuid4().hex[0:10]
+        e.text = name
         e = root.find("./devices/emulator")
         e.text = self.find_kvm_binary()
         dom = self.conn.defineXML(ET.tostring(root).decode())
-        return LibvirtDomain(dom)
+        domain = LibvirtDomain(dom)
+        domain.distro = distro
+        return domain
 
     def list_domains(self):
         for i in self.conn.listAllDomains():

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -61,10 +61,8 @@ def up(configuration, virt_lightning_yaml_path, context):
         # that symbol more well add to check encoding block
         status_line += "🗲{name} ".format(**host)
         print(status_line)
-        domain = hv.create_domain()
-        domain.distro = host["distro"]
+        domain = hv.create_domain(**host)
         domain.context(context)
-        domain.name(host["name"])
         domain.ssh_key_file(configuration.ssh_key_file)
         domain.username(configuration.username)
 


### PR DESCRIPTION
Create the domain with the final name, this to avoid the transitional
state where the VM has a temporary name.