### PR TITLE
retrieve network configuration from libvirt net

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ You can create your own configuration file like this and save to config.ini
 
 ```
 [main]
-network = 192.168.122.0/24
-gateway = 192.168.122.1/24
 bridge = virbr0
 root_password = root
 storage_pool = default

--- a/conf/example.ini
+++ b/conf/example.ini
@@ -1,6 +1,4 @@
 [main]
-network = 192.168.122.0/24
-gateway = 192.168.122.1/24
 bridge = virbr0
 root_password = root
 storage_pool = default

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 libvirt-python
+netifaces
 pyyaml

--- a/virt_lightning/__init__.py
+++ b/virt_lightning/__init__.py
@@ -12,6 +12,8 @@ import xml.etree.ElementTree as ET
 
 import libvirt
 
+import netifaces
+
 import yaml
 
 
@@ -45,8 +47,7 @@ class LibvirtHypervisor:
 
         self.conn = conn
         self.configuration = configuration
-        self.network = ipaddress.ip_network(self.configuration.network)
-        self.gateway = ipaddress.IPv4Interface(self.configuration.gateway)
+        self.init_network()
         self._last_free_ipv4 = None
         self.pool = self.conn.storagePoolLookupByName(self.configuration.storage_pool)
         self.get_storage_dir()
@@ -128,7 +129,9 @@ class LibvirtHypervisor:
             with open(temp_dir + "/meta-data", "w") as fd:
                 fd.write(
                     domain.meta_data.format(
-                        name=domain.name(), ipv4=domain.ipv4.ip, gateway=domain.gateway
+                        name=domain.name(),
+                        ipv4=str(domain.ipv4.ip),
+                        gateway=str(domain.gateway.ip),
                     )
                 )
             with open(temp_dir + "/network-config", "w") as fd:
@@ -163,6 +166,23 @@ class LibvirtHypervisor:
                 return
         else:
             raise Exception("Failed to find the kvm binary in: ", paths)
+
+    def init_network(self):
+        if self.conn.getURI().startswith("qemu:///session"):
+            bridge_name = self.configuration.bridge
+            try:
+                bridge_netiface = netifaces.ifaddresses(bridge_name)
+            except ValueError:
+                print("Bridge not found:", bridge_name)
+                exit(1)
+            ipconfig = bridge_netiface[netifaces.AF_INET]
+            self.gateway = ipaddress.IPv4Interface(
+                "{addr}/{netmask}".format(**ipconfig[0])
+            )
+            self.dns = self.gateway
+            self.network = self.gateway.network
+        elif self.conn.getURI().startswith("qemu:///system"):
+            print("system")
 
 
 class LibvirtDomain:
@@ -328,8 +348,8 @@ class LibvirtDomain:
                         "match": {"macaddress": primary_mac_addr},
                         "set-name": "interface0",
                         "addresses": [str(self.ipv4)],
-                        "gateway4": self.gateway,
-                        "nameservers": {"addresses": [self.dns]},
+                        "gateway4": str(self.gateway.ip),
+                        "nameservers": {"addresses": [str(self.dns.ip)]},
                     }
                 },
             }
@@ -346,14 +366,13 @@ class LibvirtDomain:
                             {
                                 "type": "static",
                                 "address": str(self.ipv4),
-                                "gateway": self.gateway,
-                                "dns_nameservers": [self.dns],
+                                "gateway": str(self.gateway.ip),
+                                "dns_nameservers": [str(self.dns.ip)],
                             }
                         ],
                     }
                 ],
             }
-
         nm_filter = "(centos|fedora|rhel)"
         if re.match(nm_filter, self.distro):
             nmcli_call = (
@@ -362,7 +381,9 @@ class LibvirtDomain:
             )
             self.cloud_init["runcmd"].append("nmcli -g UUID c|xargs -n 1 nmcli con del")
             self.cloud_init["runcmd"].append(
-                nmcli_call.format(ipv4=self.ipv4, gateway=self.gateway, dns=self.dns)
+                nmcli_call.format(
+                    ipv4=self.ipv4, gateway=str(self.gateway.ip), dns=str(self.dns.ip)
+                )
             )
             # Without that NM, initialize eth0 with a DHCP IP
             self.cloud_init["bootcmd"].append(

--- a/virt_lightning/configuration.py
+++ b/virt_lightning/configuration.py
@@ -10,8 +10,6 @@ DEFAULT_CONFIGFILE = "{home}/.config/virt-lightning/config.ini".format(
 DEFAULT_CONFIGURATION = {
     "main": {
         "libvirt_uri": "qemu:///system" if os.geteuid() == 0 else "qemu:///session",
-        "network": "192.168.122.0/24",
-        "gateway": "192.168.122.1/24",
         "bridge": "virbr0",
         "username": getpass.getuser(),
         "root_password": "root",
@@ -28,14 +26,6 @@ class AbstractConfiguration(metaclass=ABCMeta):
 
     @abstractproperty
     def username(self):
-        pass
-
-    @abstractproperty
-    def network(self):
-        pass
-
-    @abstractproperty
-    def gateway(self):
         pass
 
     @abstractproperty
@@ -79,14 +69,6 @@ class Configuration(AbstractConfiguration):
     @property
     def username(self):
         return self.__get("username")
-
-    @property
-    def network(self):
-        return self.__get("network")
-
-    @property
-    def gateway(self):
-        return self.__get("gateway")
 
     @property
     def bridge(self):

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -77,9 +77,7 @@ def up(configuration, virt_lightning_yaml_path, context):
         root_disk_path = hv.create_disk(name=host["name"], backing_on=host["distro"])
         domain.add_root_disk(root_disk_path)
         domain.attachBridge(configuration.bridge)
-        domain.set_ip(
-            ipv4=hv.get_free_ipv4(), gateway="192.168.122.1", dns="192.168.122.1"
-        )
+        domain.set_ip(ipv4=hv.get_free_ipv4(), gateway=hv.gateway, dns=hv.dns)
         domain.add_swap_disk(hv.create_disk(host["name"] + "-swap", size=1))
         hv.start(domain)
         sys.stdout.write(CURSOR_UP_ONE)


### PR DESCRIPTION
Collect the IPv4 configuration of the bridge interface and use it
for the definition of the guest network configuration.

closes: #17