### PR TITLE
dynamically create the storage pool

### DIFF
--- a/tests/test_foo.py
+++ b/tests/test_foo.py
@@ -1,2 +1,0 @@
-def test_foo():
-    assert True

--- a/tests/test_hv.py
+++ b/tests/test_hv.py
@@ -1,0 +1,31 @@
+import virt_lightning
+
+import pathlib
+from unittest.mock import patch
+
+
+def test_arch():
+    hv = virt_lightning.LibvirtHypervisor("test:///default")
+    assert hv.arch == 'i686'
+
+
+def test_domain_type():
+    hv = virt_lightning.LibvirtHypervisor("test:///default")
+    assert hv.domain_type == 'test'
+
+
+def test_kvm_binary():
+    def mock_exists(path):
+        if path == pathlib.PosixPath("/usr/bin/kvm"):
+            return True
+    hv = virt_lightning.LibvirtHypervisor("test:///default")
+    with patch.object(pathlib.Path, 'exists', mock_exists):
+        assert hv.kvm_binary == pathlib.PosixPath("/usr/bin/kvm")
+
+
+def test_init_storage_pool():
+    hv = virt_lightning.LibvirtHypervisor("test:///default")
+    with patch.object(pathlib.Path, 'exists') as mock_exists:
+        mock_exists.return_value = False
+        hv.init_storage_pool("foo_bar")
+    assert hv.conn.storagePoolLookupByName("foo_bar")

--- a/virt_lightning/configuration.py
+++ b/virt_lightning/configuration.py
@@ -13,7 +13,7 @@ DEFAULT_CONFIGURATION = {
         "bridge": "virbr0",
         "username": getpass.getuser(),
         "root_password": "root",
-        "storage_pool": "default",
+        "storage_pool": "virt-lightning",
         "ssh_key_file": "~/.ssh/id_rsa.pub",
     }
 }

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import os
-import pathlib
 import re
 import sys
 import time
@@ -44,7 +42,9 @@ def up(configuration, virt_lightning_yaml_path, context):
     if not host_definitions:
         return
 
-    hv = vl.LibvirtHypervisor(configuration)
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
+    hv.init_network(configuration.bridge)
+    hv.init_storage_pool(configuration.storage_pool)
 
     status_line = "Starting:"
 
@@ -115,7 +115,7 @@ def up(configuration, virt_lightning_yaml_path, context):
 
 
 def ansible_inventory(configuration, context):
-    hv = vl.LibvirtHypervisor(configuration)
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
 
     for domain in hv.list_domains():
         if domain.context() == context:
@@ -147,7 +147,7 @@ def get_status(hv, context):
 
 
 def status(configuration, context=None, live=False):
-    hv = vl.LibvirtHypervisor(configuration)
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
     results = {}
 
     symbols = get_symbols()
@@ -183,7 +183,7 @@ def status(configuration, context=None, live=False):
 
 
 def down(configuration, context):
-    hv = vl.LibvirtHypervisor(configuration)
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
     for domain in hv.list_domains():
         if context and domain.context() != context:
             continue
@@ -191,16 +191,18 @@ def down(configuration, context):
 
 
 def list_distro(configuration):
-    hv = vl.LibvirtHypervisor(configuration)
-    path = hv.get_storage_dir()
-    for path in glob.glob(path + "/upstream/*.qcow2"):
-        distro = pathlib.Path(path).stem
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
+    hv.init_storage_pool(configuration.storage_pool)
+    path = hv.get_storage_dir() / "upstream"
+    for path in sorted(path.glob("*.qcow2")):
+        distro = path.stem
         if "no-cloud-init" not in distro:
             print("- distro: {distro}".format(distro=distro))
 
 
 def storage_dir(configuration):
-    hv = vl.LibvirtHypervisor(configuration)
+    hv = vl.LibvirtHypervisor(configuration.libvirt_uri)
+    hv.init_storage_pool(configuration.storage_pool)
     print(hv.get_storage_dir())
 
 

--- a/virt_lightning/templates.py
+++ b/virt_lightning/templates.py
@@ -122,3 +122,14 @@ CLOUD_INIT_ENI = """network-interfaces: |
    netmask 255.255.255.0
    gateway {gateway}
 """
+
+STORAGE_POOL_XML = """
+<pool type='dir'>
+  <name></name>
+  <source>
+  </source>
+  <target>
+    <path></path>
+  </target>
+</pool>
+"""


### PR DESCRIPTION
With this patch, `virt-lightning` creates the  storage pool automatically.

In order to simplify the testing, the patch also:
- modifies the LibvirtHypervisor object initialization to avoid strong
  relationship with the configuration object
- makes use of the pathlib objects

closes: #18