### PR TITLE
ensure we can build the images on Ubuntu

### DIFF
--- a/images/distros/centos-7
+++ b/images/distros/centos-7
@@ -3,5 +3,5 @@ IMAGE_NAME=centos-7
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --update --install NetworkManager --run-command 'systemctl enable NetworkManager' --selinux-relabel
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && yum update -y && yum install -y NetworkManager' --run-command 'systemctl enable NetworkManager' --selinux-relabel
 }

--- a/images/distros/debian-9
+++ b/images/distros/debian-9
@@ -3,7 +3,7 @@ DOWNLOAD_URL=https://cdimage.debian.org/cdimage/openstack/current-9/${IMAGE_NAME
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --install qemu-guest-agent --run-command 'echo "auto eth0
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && apt update && apt install -y qemu-guest-agent python' --run-command 'echo "auto eth0
 allow-hotplug eth0
 source /etc/network/interfaces.d/*" > /etc/network/interfaces'
 }

--- a/images/distros/fedora-29
+++ b/images/distros/fedora-29
@@ -4,6 +4,6 @@ IMAGE_NAME=fedora-${FEDORA_VERSION}
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --update --install qemu-guest-agent,python \
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && dnf update -y && dnf install -y qemu-guest-agent python' \
         --run-command 'systemctl enable qemu-guest-agent' --selinux-relabel
 }

--- a/images/distros/ubuntu-16.04
+++ b/images/distros/ubuntu-16.04
@@ -3,5 +3,5 @@ IMAGE_NAME=ubuntu-16.04
 
 function prepare {
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --install qemu-guest-agent,python
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && apt update && apt install -y qemu-guest-agent python'
 }

--- a/images/distros/ubuntu-18.04
+++ b/images/distros/ubuntu-18.04
@@ -2,7 +2,7 @@ DOWNLOAD_URL=https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudi
 IMAGE_NAME=ubuntu-18.04
 
 function prepare {
-    update-grub because of https://bugs.launchpad.net/cloud-images/+bug/1726476
+    # update-grub because of https://bugs.launchpad.net/cloud-images/+bug/1726476
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --install qemu-guest-agent,python --run-command update-grub
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && apt update && apt install -y qemu-guest-agent python' --run-command update-grub
 }


### PR DESCRIPTION
On Ubuntu 18.04, `virt-sysprep --network` creates an environmnet without
DNS resolution. This commit introduces a work around to avoid the problem.

See: https://bugs.launchpad.net/ubuntu/+source/libguestfs/+bug/1768085