### PR TITLE
do not show anything when a pool is missing

### DIFF
--- a/virt_lightning/__init__.py
+++ b/virt_lightning/__init__.py
@@ -220,7 +220,6 @@ class LibvirtHypervisor:
             return
         except libvirt.libvirtError as e:
             if e.get_error_code() == libvirt.VIR_ERR_NO_STORAGE_POOL:
-                print("Storage pool is missing.")
                 pass
 
         if os.geteuid() == 0:


### PR DESCRIPTION
Since use `vl storage_dir` in Ansible, we cannot show up this kind of
debug message.
This is a temporary situation that will be resolved by #32.