### PR TITLE
debian: configure resolvconf

### DIFF
--- a/images/distros/debian-9
+++ b/images/distros/debian-9
@@ -2,8 +2,10 @@ IMAGE_NAME=debian-9
 DOWNLOAD_URL=https://cdimage.debian.org/cdimage/openstack/current-9/${IMAGE_NAME}-openstack-amd64.qcow2
 
 function prepare {
+    # We need resolvconf otherwise, the 'dns-nameservers' value in the /etc/network/interfaces
+    # is ignored.
     virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
-        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && apt update && apt install -y qemu-guest-agent python' --run-command 'echo "auto eth0
+        --network --run-command 'echo "nameserver 169.254.2.3" > /etc/resolv.conf && apt update && apt install -y qemu-guest-agent python resolvconf' --run-command 'echo "auto eth0
 allow-hotplug eth0
-source /etc/network/interfaces.d/*" > /etc/network/interfaces'
+source /etc/network/interfaces.d/*" > /etc/network/interfaces' --firstboot-command 'rm /etc/resolv.conf; ln -s /etc/resolvconf/run/resolv.conf /etc/resolv.conf'
 }


### PR DESCRIPTION
cloud-init uses a dns-nameservers key in /etc/network/interfaces.d/50-cloud-init.cfg
to configure the nameserver. This feature depends on resolvconf, we
have to install and configure it.