### PR TITLE
libvirt: virEventRegisterDefaultImpl() before open()

### DIFF
--- a/ansible/roles/virt_lightning/tasks/test.yml
+++ b/ansible/roles/virt_lightning/tasks/test.yml
@@ -5,6 +5,7 @@
     creates: ~/.ssh/id_rsa
 - name: Start the environment
   shell: |
+    set -eux
     echo $PATH
     vl distro_list > virt-lightning.yaml
     vl up

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -91,9 +91,8 @@ def up(virt_lightning_yaml, configuration, context, **kwargs):
         libvirtaio.virEventRegisterAsyncIOImpl(loop=loop)
     except ImportError:
         pass
-    vc = libvirt.open("qemu:///system")
-    vc.setKeepAlive(5, 3)
-    vc.domainEventRegisterAny(
+    hv.conn.setKeepAlive(5, 3)
+    hv.conn.domainEventRegisterAny(
         None,
         libvirt.VIR_DOMAIN_EVENT_ID_AGENT_LIFECYCLE,
         myDomainEventAgentLifecycleCallback,

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -53,6 +53,7 @@ def run_cmd(cmd, cwd=None):
 
 class LibvirtHypervisor:
     def __init__(self, libvirt_uri):
+        libvirt.virEventRegisterDefaultImpl()
         conn = libvirt.open(libvirt_uri)
 
         if conn is None:


### PR DESCRIPTION
This to avoid the following error with libvirt 1.3.1 (Ubuntu 16.04):

libvirt.libvirtError: internal error: the caller doesn't support keepalive protocol; perhaps it's missing event loop implementation

See: https://www.redhat.com/archives/libvirt-users/2014-April/msg00011.html