### PR TITLE
added missing string character

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -72,9 +72,9 @@ def up(virt_lightning_yaml, configuration, context, **kwargs):
 
     def start_domain(host):
         if host["distro"] not in hv.distro_available():
-            logger.error("distro not available:", host["distro"])
+            logger.error("distro not available: %s", host["distro"])
             logger.info(
-                "Please select on of the following distro:", hv.distro_available()
+                "Please select on of the following distro: %s", hv.distro_available()
             )
             exit()
 


### PR DESCRIPTION
Added missing character that remove the following stack:

--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.7/logging/__init__.py", line 1034, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.7/logging/__init__.py", line 880, in format
    return fmt.format(record)
  File "/usr/lib64/python3.7/logging/__init__.py", line 619, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.7/logging/__init__.py", line 380, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/lib64/python3.7/threading.py", line 885, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 80, in _worker
    work_item.run()
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/sebasp/.local/lib/python3.7/site-packages/virt_lightning/shell.py", line 75, in start_domain
    logger.error("distro not available:", host["distro"])
