### PR TITLE
avoid: ejectable media cannot use virtio type

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -558,8 +558,10 @@ class LibvirtDomain:
         self.record_metadata("groups", ",".join(value))
 
     def attachDisk(self, volume, device="disk", disk_type="qcow2"):
-        if self.distro.startswith("esxi"):
-            bus = "ide" if device == "cdrom" else "sata"
+        if device == "cdrom":
+            bus = "ide"
+        elif self.distro.startswith("esxi"):
+            bus = "sata"
         else:
             bus = "virtio"
         device_name = self.getNextBlckDevice()


### PR DESCRIPTION
Minor adjustment to avoid the following error with an up to date version
of libvirt:

```
libvirt.libvirtError: unsupported configuration: disk type 'virtio' of 'vdc' does not support ejectable media
```

See: https://marc.info/?l=libvir-list&m=154929531226510&w=2