### PR TITLE
hostname autogeneration: allow - char

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -39,7 +39,7 @@ def _start_domain(hv, host, context, configuration):
         exit()
 
     if "name" not in host:
-        host["name"] = re.sub(r"\W+", "", host["distro"])
+        host["name"] = re.sub(r"[^a-zA-Z0-9-]+", "", host["distro"])
 
     if hv.get_domain_by_name(host["name"]):
         logger.info("Skipping {name}, already here.".format(**host))


### PR DESCRIPTION
When no hostname is set, virt-lightning generates a new on based on
the name of the distro. With this change, itt won't strip the '-' character
from the distro name anymore.