### PR TITLE
start: pass --memory and --vcpus properly

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -131,7 +131,7 @@ def start(configuration, **kwargs):
     hv = vl.LibvirtHypervisor(conn)
     hv.init_network(configuration.network_name, configuration.network_cidr)
     hv.init_storage_pool(configuration.storage_pool)
-    host = {"distro": kwargs["distro"]}
+    host = {k: kwargs[k] for k in ["distro", "memory", "vcpus"] if kwargs.get(k)}
     context = "default"
     domain = _start_domain(hv, host, context, configuration)
     if not domain:


### PR DESCRIPTION
`vl start` do not ignore the `--memory` and `--vcpus` parameter anymore.