### PR TITLE
clean up the network

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -313,6 +313,7 @@ def down(configuration, context, **kwargs):
             continue
         logger.info("%s purging %s", symbols.TRASHBIN.value, domain.name)
         hv.clean_up(domain)
+    hv.network_obj.destroy()
 
 
 def distro_list(configuration, **kwargs):

--- a/virt_lightning/templates.py
+++ b/virt_lightning/templates.py
@@ -115,7 +115,9 @@ NETWORK_XML = """
   <forward mode='nat'/>
   <bridge name='virbr0' stp='off' delay='0'/>
   <ip address='192.168.123.1' netmask='255.255.255.0'>
-  <dhcp />
+  <dhcp>
+    <leasetime>10s</leasetime>
+  </dhcp>
   </ip>
 </network>
 """

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -415,6 +415,8 @@ class LibvirtHypervisor:
     def dns_entry(self, command, name, ipv4):
         root = ET.fromstring(NETWORK_HOST_ENTRY)
         root.find("./hostname").text = name
+        if command == libvirt.VIR_NETWORK_UPDATE_COMMAND_DELETE and not ipv4:
+            return
         root.attrib["ip"] = str(ipv4.ip)
         xml = ET.tostring(root).decode()
         try:
@@ -436,6 +438,8 @@ class LibvirtHypervisor:
         root = ET.fromstring(NETWORK_DHCP_ENTRY)
         if mac:
             root.attrib["mac"] = mac
+        if command == libvirt.VIR_NETWORK_UPDATE_COMMAND_DELETE and not ipv4:
+            return
         root.attrib["ip"] = str(ipv4.ip)
         xml = ET.tostring(root).decode()
         try:


### PR DESCRIPTION
- destroy the `virt-lightning` network at the end of the run.
- try harder to delete the existing DHCP/DNS record
- reduce the lease duration to be sure the IP will be quickly freed