### PR TITLE
use openstack metadata format by default

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -68,7 +68,7 @@ def _start_domain(hv, host, context, configuration):
     domain.attachNetwork(configuration.network_name)
     domain.ipv4 = hv.get_free_ipv4()
     domain.add_swap_disk(hv.create_disk(host["name"] + "-swap", size=1))
-    hv.start(domain)
+    hv.start(domain, metadata_format=host.get("metadata_format", {}))
     return domain
 
 


### PR DESCRIPTION
OpenStack's network metadata is well supported and, this allow us to
remove a series of hack that was needed with the NoCloud format.

NoCloud is still the default for RHEL6 and CentOS6.