### PR TITLE
add ability to define several NIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,4 +281,9 @@ cat /var/lib/virt-lightning/pool/upstream/esxi-6.7.yaml
 username: root
 python_interpreter: /bin/python
 memory: 4096
+networks:
+  - network: virt-lightning
+    nic_model: virtio
+  - network: default
+    nic_model: e1000
 ```

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -59,6 +59,7 @@ def _start_domain(hv, host, context, configuration):
         "ssh_key_file": host.get("ssh_key_file", configuration.ssh_key_file),
         "username": host.get("username"),
         "vcpus": host.get("vcpus"),
+        "default_nic_mode": host.get("default_nic_model"),
     }
     domain = hv.create_domain(name=host["name"], distro=host["distro"])
     hv.configure_domain(domain, user_config)
@@ -69,7 +70,8 @@ def _start_domain(hv, host, context, configuration):
         size=host.get("root_disk_size", 15),
     )
     domain.add_root_disk(root_disk_path)
-    domain.attachNetwork(configuration.network_name)
+    for network in host.get("networks", [{"network": configuration.network_name}]):
+        domain.attachNetwork(**network)
     domain.ipv4 = hv.get_free_ipv4()
     domain.add_swap_disk(hv.create_disk(host["name"] + "-swap", size=1))
     hv.start(domain, metadata_format=host.get("metadata_format", {}))

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -114,6 +114,7 @@ class LibvirtHypervisor:
             "root_password": "root",
             "username": getpass.getuser(),
             "vcpus": 1,
+            "default_nic_model": "virtio",
         }
         for k, v in self.get_distro_configuration(domain.distro).items():
             if v:
@@ -128,6 +129,7 @@ class LibvirtHypervisor:
         domain.root_password = config["root_password"]
         domain.username = config["username"]
         domain.vcpus = config["vcpus"]
+        domain.default_nic_model = config["default_nic_model"]
 
     def get_distro_configuration(self, distro):
         distro_configuration_file = pathlib.PosixPath(
@@ -566,6 +568,7 @@ class LibvirtDomain:
             "dsmode: local\n" "instance-id: iid-{name}\n" "local-hostname: {name}\n"
         )
         self._ssh_key = None
+        self.default_nic_model = None
 
     @property
     def root_password(self):
@@ -741,11 +744,12 @@ class LibvirtDomain:
         self.dom.attachDeviceFlags(xml, libvirt.VIR_DOMAIN_AFFECT_CONFIG)
         return device_name
 
-    def attachNetwork(self, network=None):
+    def attachNetwork(self, network=None, nic_model=None):
+        if not nic_model:
+            nic_model = self.default_nic_model
         disk_root = ET.fromstring(BRIDGE_XML)
         disk_root.findall("./source")[0].attrib = {"network": network}
-        if self.distro.startswith("esxi"):
-            disk_root.findall("./model")[0].attrib = {"type": "e1000"}
+        disk_root.findall("./model")[0].attrib = {"type": nic_model}
 
         xml = ET.tostring(disk_root).decode()
         self.dom.attachDeviceFlags(xml, libvirt.VIR_DOMAIN_AFFECT_CONFIG)


### PR DESCRIPTION
- IP is attached to the first NIC by default
- default type is `virtio`
- add two new keys: `default_nic_model` and `nic_model` to overwrite the
  default NIC driver (`virtio`)