### PR TITLE
vcpu: correctly cap the number of CPU

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -37,3 +37,8 @@ def test_mac_addresses(domain):
     with patch.object(domain.dom, 'XMLDesc', xmlDesc) as mock_xmldesc:
         print(domain.mac_addresses)
         assert domain.mac_addresses
+
+def test_vcpus(domain):
+  assert domain.vcpus > 0
+  domain.vcpus = 2
+  assert domain.vcpus == 2

--- a/virt_lightning/templates.py
+++ b/virt_lightning/templates.py
@@ -23,7 +23,7 @@ DOMAIN_XML = """
   </features>
   <cpu mode='host-model' check='partial'>
     <model fallback='allow'/>
-  </cpu>uu
+  </cpu>
   <clock offset='utc'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -655,6 +655,14 @@ class LibvirtDomain:
     def name(self, name):
         self.dom.rename(name, 0)
 
+    @property
+    def vcpus(self):
+        xml = self.dom.XMLDesc(0)
+        root = ET.fromstring(xml)
+        vcpu = root.findall("./vcpu")[0]
+        return int(vcpu.attrib.get("current", vcpu.text))
+
+    @vcpus.setter
     def vcpus(self, value=1):
         self.dom.setVcpusFlags(value, libvirt.VIR_DOMAIN_AFFECT_CONFIG)
 


### PR DESCRIPTION
Since 620ddeeaee52438bf984f5478fc5149575e60ae3, all the CPUs were
attached and active. Now we can still potentially increase the number
of the CPU, but only some of them are active (only the defined in `vcpus`).