### PR TITLE
do not set any default python interpreter

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -110,7 +110,6 @@ class LibvirtHypervisor:
         config = {
             "groups": [],
             "memory": 768,
-            "python_interpreter": "/usr/bin/python3",
             "root_password": "root",
             "username": getpass.getuser(),
             "vcpus": 1,


### PR DESCRIPTION
To can be source of misconfiguration, it's better to let Ansible deal
with the situation.