### PR TITLE
memory: set the current the amount of memory

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -690,7 +690,7 @@ class LibvirtDomain:
         self.dom.setMemoryFlags(
             value, libvirt.VIR_DOMAIN_AFFECT_CONFIG | libvirt.VIR_DOMAIN_MEM_MAXIMUM
         )
-        self._memory = value
+        self.dom.setMemoryFlags(value, libvirt.VIR_DOMAIN_AFFECT_CONFIG)
 
     def getNextBlckDevice(self):
         if not hasattr(self, "blockdev"):


### PR DESCRIPTION
So far, we only define the maximum amount of memory for a VM. The
allocation was still at 768MB by default.
 "If VIR_DOMAIN_MEM_MAXIMUM is set, the change affects domain's maximum
memory size rather than current memory size."

With this change, we ensure the VM get the amount of memory that we
expect.

See: https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainSetMemoryFlags