### PR TITLE
metadata: pass the root_password in `admin_pass`

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -237,6 +237,7 @@ class LibvirtHypervisor:
                 "meta": {},
                 "public_keys": {"default": domain.ssh_key},
                 "uuid": domain.dom.UUIDString(),
+                "admin_pass": domain.root_password,
             }
             openstack_network_data = {
                 "links": [


### PR DESCRIPTION
See: https://blueprints.launchpad.net/cloud-init/+spec/set-image-root-password