### PR TITLE
remove_domain_from_network: ignore host with no IP

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -275,7 +275,7 @@ def get_status(hv, context):
         status.append(
             {
                 "name": name,
-                "ipv4": str(domain.ipv4.ip),
+                "ipv4": domain.ipv4 and str(domain.ipv4.ip),
                 "context": domain.context,
                 "username": domain.username,
             }

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -405,6 +405,8 @@ class LibvirtHypervisor:
 
     def remove_domain_from_network(self, domain):
         root = ET.fromstring(self.network_obj.XMLDesc(0))
+        if not domain.ipv4:
+            return
         for host in root.findall("./dns/host[@ip]"):
             if host.attrib["ip"] != str(domain.ipv4.ip):
                 continue


### PR DESCRIPTION
Host may have no IP configuration, in this case, we just ignore it.