### PR TITLE
Issue #137

### DIFF
--- a/virt_lightning/configuration.py
+++ b/virt_lightning/configuration.py
@@ -12,6 +12,7 @@ DEFAULT_CONFIGURATION = {
         "storage_pool": "virt-lightning",
         "network_name": "virt-lightning",
         "network_cidr": "192.168.123.0/24",
+        "network_del":  True,
         "ssh_key_file": "~/.ssh/id_rsa.pub",
     }
 }
@@ -28,6 +29,10 @@ class AbstractConfiguration(metaclass=ABCMeta):
 
     @abstractproperty
     def network_cidr(self):
+        pass
+
+    @abstractproperty
+    def network_del(self):
         pass
 
     @abstractproperty
@@ -69,6 +74,10 @@ class Configuration(AbstractConfiguration):
     @property
     def network_cidr(self):
         return self.__get("network_cidr")
+
+    @property
+    def network_del(self):
+        return self.__get("network_del")
 
     @property
     def root_password(self):

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import urllib.request
 import sys
+import distutils.util
 
 import libvirt
 import yaml
@@ -343,7 +344,9 @@ def down(configuration, context, **kwargs):
             continue
         logger.info("%s purging %s", symbols.TRASHBIN.value, domain.name)
         hv.clean_up(domain)
-    hv.network_obj.destroy()
+
+    if bool(distutils.util.strtobool(configuration.network_del)):
+        hv.network_obj.destroy()
 
 
 def distro_list(configuration, **kwargs):


### PR DESCRIPTION
Adds the configuration option 'network_del' with a default value of True. Gate destroying the network with a check of this configuration option, cast to a bool. This retains the previous behavior (unilaterally delete the network on vl down) as the default behavior.

I opted for this instead of checking if anything was still attached to the network - that method was going to add a substantial amount of overhead to handle the case of stopped VMs that still reference the network. For my use cases at least, I'll manually create the network virt-lightning uses and then it'll be permanent on the hypervisor.