### PR TITLE
Check context before appending to ansible groups

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -206,13 +206,13 @@ def ansible_inventory(configuration, context, **kwargs):
 
     groups = {}
     for domain in hv.list_domains():
+        if domain.context != context:
+            continue
+
         for group in domain.groups:
             if group not in groups:
                 groups[group] = []
             groups[group].append(domain)
-
-        if domain.context != context:
-            continue
 
         template = ssh_cmd_template
 


### PR DESCRIPTION
Checking if the domain context matches the context from the command line should happen before the ansible groups arrays are built. This prevents hosts in the same ansible group from different contexts/projects slipping into a group definition.

With this change:
```
$ vl ansible_inventory --context project2
test-5 ansible_host=192.168.123.6 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
test-4 ansible_host=192.168.123.7 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"

[test-centos]
test-5

[test-ubuntu]
test-4

$ vl ansible_inventory --context project1
test-3 ansible_host=192.168.123.85 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
test-2 ansible_host=192.168.123.5 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"

[test-centos]
test-3

[test-ubuntu]
test-2
```

Without it:
```
$ vl ansible_inventory --context project2
test-5 ansible_host=192.168.123.6 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
test-4 ansible_host=192.168.123.7 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"

[test-centos]
test-5
test-3

[test-ubuntu]
test-4
test-2

$ vl ansible_inventory --context project1
test-3 ansible_host=192.168.123.85 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
test-2 ansible_host=192.168.123.5 ansible_user=zdykstra ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"

[test-centos]
test-5
test-3

[test-ubuntu]
test-4
test-2
```
