### PR TITLE
Add in virt-viewer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ Like `vl ssh` but with the serial console of the VM.
 
 [![vl ssh](https://asciinema.org/a/230677.svg)](https://asciinema.org/a/230677?autoplay=1)
 
+
+## **vl viewer**
+
+Like `vl console` but with the SPICE console of the VM. Requires `virt-viewer`.
+
 ## **vl fetch**
 
 Fetch a VM image. [You can find here a list of the available images](https://virt-lightning.org/images/).

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -338,13 +338,23 @@ def viewer(configuration, name=None, **kwargs):
     conn = libvirt.open(configuration.libvirt_uri)
     hv = vl.LibvirtHypervisor(conn)
 
+    def virt_viewer_binary():
+        paths = [
+            pathlib.PosixPath(i, "virt-viewer")
+            for i in os.environ["PATH"].split(os.pathsep)
+        ]
+        for exe in paths:
+            if exe.exists():
+                return exe
+        raise Exception("Failed to find virt-viewer in: ", paths)
+
     def go_viewer(domain):
         pid = os.fork()
         if pid == 0:
             os.close(1)
             os.close(2)
             os.execlp(
-                "virt-viewer",
+                virt_viewer_binary(),
                 "virt-viewer",
                 "-c",
                 configuration.libvirt_uri,

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -334,6 +334,32 @@ def console(configuration, name=None, **kwargs):
     ui.Selector(sorted(hv.list_domains()), go_console)
 
 
+def viewer(configuration, name=None, **kwargs):
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+
+    def go_viewer(domain):
+        pid = os.fork()
+        if pid == 0:
+            os.close(1)
+            os.close(2)
+            os.execlp(
+                "virt-viewer",
+                "virt-viewer",
+                "-c",
+                configuration.libvirt_uri,
+                "--domain-name",
+                domain.name,
+            )
+        else:
+            sys.exit(0)
+
+    if name:
+        go_viewer(hv.get_domain_by_name(name))
+
+    ui.Selector(sorted(hv.list_domains()), go_viewer)
+
+
 def down(configuration, context, **kwargs):
     conn = libvirt.open(configuration.libvirt_uri)
     hv = vl.LibvirtHypervisor(conn)
@@ -428,7 +454,7 @@ def main():
 
     usage = """
 usage: vl [--debug DEBUG] [--config CONFIG]
-          {up,down,start,distro_list,storage_dir,ansible_inventory, ssh_config} ..."""
+          {up,down,start,distro_list,storage_dir,ansible_inventory,ssh_config,console,viewer} ..."""
     example = """
 Example:
 
@@ -559,6 +585,13 @@ Example:
         "console", help="Open the console of a given host", parents=[parent_parser]
     )
     console_parser.add_argument("name", help="Name of the host", type=str, nargs="?")
+
+    viewer_parser = action_subparsers.add_parser(
+        "viewer",
+        help="Open the SPICE console of a given host with virt-viewer",
+        parents=[parent_parser],
+    )
+    viewer_parser.add_argument("name", help="Name of the host", type=str, nargs="?")
 
     fetch_parser = action_subparsers.add_parser(
         "fetch", help="Fetch a VM image", parents=[parent_parser]


### PR DESCRIPTION
Add the `viewer` command line option. This can be used to open a `virt-viewer` console for a domain. This is useful when you need to see what happens in a VM before the kernel starts.

It performs a single fork and closes stdout and stderr.