### PR TITLE
flake8: ignore E501 line too long

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,4 @@ line_length=90
 [flake8]
 max-line-length = 90
 inline-quotes = "
-ignore = C812,S404,S405,S314
+ignore = C812,S404,S405,S314,E501


### PR DESCRIPTION
Black code formatter tends to go slightly above the historical 80 characters
limit. We don't really need this flake8 check since Black will anyway check
the line lenght by itself.

See: https://github.com/psf/black#line-length