### PR TITLE
honor the bootcmd config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ A VM can be tunned at two different places with the following keys:
   networks:
     - network: default
       ipv4: 192.168.122.50
+  bootcmd:
+    - yum update -y
 ```
 
 ### You can also associate some parameters to the distro image itself

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -62,6 +62,7 @@ def _start_domain(hv, host, context, configuration):
         "vcpus": host.get("vcpus"),
         "fqdn": host.get("fqdn"),
         "default_nic_mode": host.get("default_nic_model"),
+        "bootcmd": host.get("bootcmd"),
     }
     domain = hv.create_domain(name=host["name"], distro=host["distro"])
     hv.configure_domain(domain, user_config)

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -120,6 +120,7 @@ class LibvirtHypervisor:
             "username": getpass.getuser(),
             "vcpus": 1,
             "default_nic_model": "virtio",
+            "bootcmd": [],
         }
         for k, v in self.get_distro_configuration(domain.distro).items():
             if v:
@@ -135,6 +136,7 @@ class LibvirtHypervisor:
         domain.username = config["username"]
         domain.vcpus = config["vcpus"]
         domain.default_nic_model = config["default_nic_model"]
+        domain.bootcmd = config["bootcmd"]
         if "fqdn" in config:
             domain.fqdn = config["fqdn"]
 
@@ -838,6 +840,16 @@ class LibvirtDomain:
     @ipv4.setter
     def ipv4(self, value):
         self.record_metadata("ipv4", value)
+
+    @property
+    def bootcmd(self):
+        return self.user_data["bootcmd"]
+
+    @bootcmd.setter
+    def bootcmd(self, value):
+        if not hasattr(value, "append"):
+            raise ValueError("bootcmd should be a list of command")
+        self.user_data["bootcmd"] = value
 
     @property
     def mac_addresses(self):


### PR DESCRIPTION
honor the bootcmd config key
    
`bootcmd` commands are evaluated by cloud-init after the very first boot
of the VM.
    
See: https://cloudinit.readthedocs.io/en/latest/topics/examples.html#run-commands-on-first-boot