### PR TITLE
openstack: also set dns_nameservers key

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -275,6 +275,7 @@ class LibvirtHypervisor:
                             }
                         ],
                         "network_id": "da5bb487-5193-4a65-a3df-4a0055a8c0d7",
+                        "dns_nameservers": [str(self.dns.ip)],
                     }
                 ],
                 "services": [{"type": "dns", "address": str(self.dns.ip)}],


### PR DESCRIPTION
Also use the `dns_nameservers` key to define the DNS server.