### PR TITLE
ability to set the IP of the other nics

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ A VM can be tunned at two different places with the following keys:
 - `root_password`: the root password in clear text
 - `groups`: this list of groups will be used if you generate an Ansible inventory.
 - `networks`: a list of network to attach to the VM. The default is: one virtio interface attached to `virt-lightning` network.
-    - `network`: the name of the network. Default is `virt-lightning`
-    - `ipv4`: a static IPv4, this key is only accepted for the first network. Default is a dynamic IPv4 address.
+    - `network`: the name of the network. Default is the key `network_name` from the configuration (`virt-lightning` by default)
+    - `ipv4`: a static IPv4. Default is a dynamic IPv4 address.
     - `nic_model`: the libvirt driver to use. Default is `virtio`
 
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -34,15 +34,6 @@ def test_load_ssh_key(domain, tmp_path):
     assert domain.ssh_key == CONTENT
 
 
-def test_mac_addresses(domain):
-    def xmlDesc(i):
-        return IF_XML
-
-    with patch.object(domain.dom, "XMLDesc", xmlDesc) as mock_xmldesc:
-        print(domain.mac_addresses)
-        assert domain.mac_addresses
-
-
 def test_vcpus(domain):
     assert domain.vcpus > 0
     domain.vcpus = 2

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -73,8 +73,10 @@ def _start_domain(hv, host, context, configuration):
         size=host.get("root_disk_size", 15),
     )
     domain.add_root_disk(root_disk_path)
-    networks = host.get("networks", [{"network": configuration.network_name}])
+    networks = host.get("networks", [{}])
     for i, network in enumerate(networks):
+        if "network" not in network:
+            network["network"] = configuration.network_name
         if i == 0 and not network.get("ipv4"):
             network["ipv4"] = hv.get_free_ipv4()
         domain.attachNetwork(**network)


### PR DESCRIPTION
So far, it was possible to add extra NIC, but the ipv4 configuration was
ignore. This commit adds the ability to specific what statuc IPv4 should be
set.

See also: https://github.com/virt-lightning/virt-lightning/pull/153

Tested with the following configuration:

```yaml
- distro: centos-7
  networks:
    - ipv4: 192.168.123.50
    - network: default
      ipv4: 192.168.122.50
    - network: foobar
- distro: centos-6
  provider: nocloud
  networks:
    - ipv4: 192.168.123.51
    - network: default
      ipv4: 192.168.122.51
    - network: foobar
```

Closes: #145