### PR TITLE
get_network_gateway: do not overwrite self.network_obj

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -539,11 +539,11 @@ class LibvirtHypervisor:
 
     def get_network_gateway(self, network_name):
         try:
-            self.network_obj = self.conn.networkLookupByName(network_name)
+            network_obj = self.conn.networkLookupByName(network_name)
         except libvirt.libvirtError as e:
             if e.get_error_code() != libvirt.VIR_ERR_NO_NETWORK:
                 raise (e)
-        xml = self.network_obj.XMLDesc(0)
+        xml = network_obj.XMLDesc(0)
         root = ET.fromstring(xml)
         ip = root.find("./ip")
 


### PR DESCRIPTION
Prevent `get_network_gateway()` from overwriting `self.network_obj`.