### PR TITLE
ConnectionRefusedError inherite from OSError

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -923,7 +923,7 @@ class LibvirtDomain:
                         )
                     )
                     return
-            except (OSError, ConnectionRefusedError):
+            except OSError:
                 pass
 
     def exec_ssh(self):


### PR DESCRIPTION
No need to test ConnectionRefusedError and OSError as the same time.