### PR TITLE
reuse_mac_address: handle the case ipv4 is not set

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -80,7 +80,7 @@ def _start_domain(hv, host, context, configuration):
         if i == 0 and not network.get("ipv4"):
             network["ipv4"] = hv.get_free_ipv4()
         network["mac"] = hv.reuse_mac_address(
-            network["network"], host["name"], network["ipv4"]
+            network["network"], host["name"], network.get("ipv4")
         )
         domain.attachNetwork(**network)
     hv.start(domain, metadata_format=host.get("metadata_format", {}))


### PR DESCRIPTION
The 'ipv4' key be unset. In this case, we just return `None` to avoid
the `KeyError` exception.