### PR TITLE
refactoring: introduce API module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# 2.0.0
+
+Main change is the introduction of the api module. It exposes a public API.
+
+- api.py: new public API module
+- shell.py: consume `api.py`
+
 # 1.1.0
 
 Main changes are the RHEL8 support and `fetch` action to retrieve images:

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps = flake8
        flake8-type-annotations
        flake8-broken-line
        flake8-print
+       pep8-naming
 commands = flake8 --exclude=version.py setup.py virt_lightning
 
 [testenv:black]

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+
+from concurrent.futures import ThreadPoolExecutor
+import logging
+
+import asyncio
+import libvirt
+import re
+import pathlib
+
+import urllib.request
+import sys
+import distutils.util
+
+from virt_lightning.symbols import get_symbols
+
+
+import virt_lightning.virt_lightning as vl
+
+logger = logging.getLogger("virt_lightning")
+
+
+def libvirt_callback(userdata, err):
+    pass
+
+
+libvirt.registerErrorHandler(f=libvirt_callback, ctx=None)
+symbols = get_symbols()
+
+MB = 1024 * 1000
+
+
+def _register_aio_virt_impl(loop):
+    # Ensure we may call shell.up() multiple times
+    # from the same asyncio program.
+    loop = loop or asyncio.get_event_loop()
+    if loop not in _register_aio_virt_impl.aio_virt_bindinds:
+        try:
+            import libvirtaio
+
+            libvirtaio.virEventRegisterAsyncIOImpl(loop=loop)
+        except ImportError:
+            libvirt.virEventRegisterDefaultImpl()
+        _register_aio_virt_impl.aio_virt_bindinds[loop] = True
+
+
+_register_aio_virt_impl.__dict__["aio_virt_bindinds"] = {}
+
+
+def _start_domain(hv, host, context, configuration):
+    if host["distro"] not in hv.distro_available():
+        logger.error("distro not available: %s", host["distro"])
+        logger.info(
+            "Please select on of the following distro: %s", hv.distro_available()
+        )
+        exit()
+
+    if "name" not in host:
+        host["name"] = re.sub(r"[^a-zA-Z0-9-]+", "", host["distro"])
+
+    if hv.get_domain_by_name(host["name"]):
+        logger.info("Skipping {name}, already here.".format(**host))
+        return
+
+    # Unfortunatly, i can't decode that symbol
+    # that symbol more well add to check encoding block
+    logger.info("{lightning} {name} ".format(lightning=symbols.LIGHTNING.value, **host))
+
+    user_config = {
+        "groups": host.get("groups"),
+        "memory": host.get("memory"),
+        "python_interpreter": host.get("python_interpreter"),
+        "root_password": host.get("root_password", configuration.root_password),
+        "ssh_key_file": host.get("ssh_key_file", configuration.ssh_key_file),
+        "username": host.get("username"),
+        "vcpus": host.get("vcpus"),
+        "fqdn": host.get("fqdn"),
+        "default_nic_mode": host.get("default_nic_model"),
+        "bootcmd": host.get("bootcmd"),
+    }
+    domain = hv.create_domain(name=host["name"], distro=host["distro"])
+    hv.configure_domain(domain, user_config)
+    domain.context = context
+    root_disk_path = hv.create_disk(
+        name=host["name"],
+        backing_on=host["distro"],
+        size=host.get("root_disk_size", 15),
+    )
+    domain.add_root_disk(root_disk_path)
+    networks = host.get("networks", [{}])
+    for i, network in enumerate(networks):
+        if "network" not in network:
+            network["network"] = configuration.network_name
+        if i == 0 and not network.get("ipv4"):
+            network["ipv4"] = hv.get_free_ipv4()
+        network["mac"] = hv.reuse_mac_address(
+            network["network"], host["name"], network.get("ipv4")
+        )
+        domain.attachNetwork(**network)
+    hv.start(domain, metadata_format=host.get("metadata_format", {}))
+    return domain
+
+
+def up(virt_lightning_yaml, configuration, context="default", **kwargs):
+    """
+    Create a list of VM
+    """
+
+    def myDomainEventAgentLifecycleCallback(conn, dom, state, reason, opaque):
+        if state == 1:
+            logger.info("%s %s QEMU agent found", symbols.CUSTOMS.value, dom.name())
+
+    loop = kwargs.get("loop") or asyncio.get_event_loop()
+    _register_aio_virt_impl(loop)
+
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+
+    conn.setKeepAlive(5, 3)
+    conn.domainEventRegisterAny(
+        None,
+        libvirt.VIR_DOMAIN_EVENT_ID_AGENT_LIFECYCLE,
+        myDomainEventAgentLifecycleCallback,
+        None,
+    )
+
+    hv.init_network(configuration.network_name, configuration.network_cidr)
+    hv.init_storage_pool(configuration.storage_pool)
+
+    pool = ThreadPoolExecutor(max_workers=10)
+
+    async def deploy():
+        futures = []
+        for host in virt_lightning_yaml:
+            futures.append(
+                loop.run_in_executor(
+                    pool, _start_domain, hv, host, context, configuration
+                )
+            )
+
+        domain_reachable_futures = []
+        for f in futures:
+            await f
+            domain = f.result()
+            if domain:
+                domain_reachable_futures.append(domain.reachable())
+        logger.info("%s ok Waiting...", symbols.HOURGLASS.value)
+
+        await asyncio.gather(*domain_reachable_futures)
+
+    loop.run_until_complete(deploy())
+    logger.info("%s You are all set", symbols.THUMBS_UP.value)
+
+
+def start(configuration, context="default", enable_console=False, **kwargs):
+    """
+    Start a single VM
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_network(configuration.network_name, configuration.network_cidr)
+    hv.init_storage_pool(configuration.storage_pool)
+    host = {
+        k: kwargs[k] for k in ["name", "distro", "memory", "vcpus"] if kwargs.get(k)
+    }
+    domain = _start_domain(hv, host, context, configuration)
+    if not domain:
+        return
+
+    loop = asyncio.get_event_loop()
+
+    if enable_console:
+        import time
+
+        time.sleep(4)
+        stream = conn.newStream(libvirt.VIR_STREAM_NONBLOCK)
+        console = domain.dom.openConsole(None, stream, 0)
+
+        loop = kwargs.get("loop") or asyncio.get_event_loop()
+        _register_aio_virt_impl(loop)
+
+        def stream_callback(stream, events, _):
+            content = stream.recv(1024).decode()
+            sys.stdout.write(content)
+
+        stream.eventAddCallback(
+            libvirt.VIR_STREAM_EVENT_READABLE, stream_callback, console
+        )
+
+    async def deploy():
+        await domain.reachable()
+
+    loop.run_until_complete(deploy())
+    logger.info(  # noqa: T001
+        (
+            "\033[0m\n**** System is online ****\n"
+            "To connect use:\n"
+            "  vl console %s (virsh console)"
+            "  vl ssh %s"
+        ),
+        domain.name,
+        domain.name,
+    )
+    if kwargs.get("ssh"):
+        domain.exec_ssh()
+
+
+def stop(configuration, **kwargs):
+    """
+    Stop a given VM
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_network(configuration.network_name, configuration.network_cidr)
+    hv.init_storage_pool(configuration.storage_pool)
+    domain = hv.get_domain_by_name(kwargs["name"])
+    if not domain:
+        vm_list = [d.name for d in hv.list_domains()]
+        if vm_list:
+            logger.info("No VM called %s in: %s", kwargs["name"], ", ".join(vm_list))
+        else:
+            logger.info("No running VM.")
+        exit(1)
+    hv.clean_up(domain)
+
+
+def ansible_inventory(configuration, context="default", **kwargs):
+    """
+    Generate an Ansible inventory based on the running VM
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+
+    ssh_cmd_template = (
+        "{name} ansible_host={ipv4} ansible_user={username} "
+        "ansible_python_interpreter={python_interpreter} "
+        'ansible_ssh_common_args="-o UserKnownHostsFile=/dev/null '
+        '-o StrictHostKeyChecking=no"\n'
+    )
+
+    output = ""
+    groups = {}
+    for domain in hv.list_domains():
+        if domain.context != context:
+            continue
+
+        for group in domain.groups:
+            if group not in groups:
+                groups[group] = []
+            groups[group].append(domain)
+
+        template = ssh_cmd_template
+
+        output += template.format(
+            name=domain.name,
+            username=domain.username,
+            ipv4=domain.ipv4.ip,
+            python_interpreter=domain.python_interpreter,
+        )  # noqa: T001
+
+    for group_name, domains in groups.items():
+        output += "\n[{group_name}]\n".format(group_name=group_name)
+        for domain in domains:
+            output += domain.name + "\n"
+    return output
+
+
+def ssh_config(configuration, context="default", **kwargs):
+    """
+    Generate an SSH configuration based on the running VM
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+
+    ssh_host_template = (
+        "Host {name}\n"
+        "     Hostname {ipv4}\n"
+        "     User {username}\n"
+        "     IdentityFile {ssh_key_file}\n"
+    )
+
+    output = ""
+    groups = {}
+    for domain in hv.list_domains():
+        for group in domain.groups:
+            groups[group].append(domain)
+
+        if domain.context != context:
+            continue
+
+        template = ssh_host_template
+
+        output += template.format(
+            name=domain.name,
+            username=domain.username,
+            ipv4=domain.ipv4.ip,
+            ssh_key_file=domain.ssh_key,
+        )
+
+    for group_name, domains in groups.items():
+        output += "\n[{group_name}]".format(group_name=group_name)
+        for domain in domains:
+            output += domain.name
+    return output
+
+
+def status(configuration, context="default", name=None, **kwargs):
+    """
+    Returns the status of the VM of the envionment
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+
+    for domain in hv.list_domains():
+        if context and context != domain.context:
+            continue
+        name = domain.name
+        if not domain.ipv4:  # Not a VL managed VM
+            continue
+        yield {
+            "name": name,
+            "ipv4": domain.ipv4 and str(domain.ipv4.ip),
+            "context": domain.context,
+            "username": domain.username,
+        }
+
+
+def exec_ssh(configuration, name=None, **kwargs):
+    """
+    Open an SSH connection on a host
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.get_domain_by_name(name).exec_ssh()
+
+
+def list_domains(configuration, name=None, **kwargs):
+    """
+    Return a list Python-libvirt instance of the running libvirt VM.
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    return sorted(hv.list_domains())
+
+
+def down(configuration, context="default", **kwargs):
+    """
+    Stop and remove a running environment.
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_network(configuration.network_name, configuration.network_cidr)
+    hv.init_storage_pool(configuration.storage_pool)
+    for domain in hv.list_domains():
+        if domain.context != context:
+            continue
+        logger.info("%s purging %s", symbols.TRASHBIN.value, domain.name)
+        hv.clean_up(domain)
+
+    if bool(distutils.util.strtobool(configuration.network_auto_clean_up)):
+        hv.network_obj.destroy()
+
+
+def distro_list(configuration, **kwargs):
+    """
+    Return a list of VM images that are available on the system.
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_storage_pool(configuration.storage_pool)
+    return hv.distro_available()
+
+
+def storage_dir(configuration, **kwargs):
+    """
+    Return the location of the VM image storage directory.
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_storage_pool(configuration.storage_pool)
+    return hv.get_storage_dir()
+
+
+def fetch(configuration, progress_callback=None, **kwargs):
+    """
+    Retrieve a VM image from Internet.
+    """
+    conn = libvirt.open(configuration.libvirt_uri)
+    hv = vl.LibvirtHypervisor(conn)
+    hv.init_storage_pool(configuration.storage_pool)
+    storage_dir = hv.get_storage_dir()
+
+    try:
+        r = urllib.request.urlopen(
+            "https://virt-lightning.org/images/{distro}/{distro}.qcow2".format(**kwargs)
+        )
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            logger.error(
+                (
+                    "Distro %s not found!\n"
+                    "Visit https://virt-lightning.org/images/ "
+                    "to get an up to date list."
+                ),
+                kwargs["distro"],
+            )
+
+            sys.exit(1)
+        else:
+            logger.exception(e)
+            sys.exit(1)
+    lenght = int(r.headers["Content-Length"])
+    chunk_size = MB * 1
+    target_file = pathlib.PosixPath(
+        "{storage_dir}/upstream/{distro}.qcow2".format(
+            storage_dir=storage_dir, **kwargs
+        )
+    )
+    temp_file = target_file.with_suffix(".temp")
+    if target_file.exists():
+        logger.info(
+            "File already exists: {target_file}".format(target_file=target_file)
+        )
+        return
+    with temp_file.open("wb") as fd:
+        while fd.tell() < lenght:
+            chunk = r.read(chunk_size)
+            fd.write(chunk)
+            if progress_callback:
+                progress_callback(fd.tell(), lenght)
+    temp_file.rename(target_file)
+    try:
+        r = urllib.request.urlopen(
+            "https://virt-lightning.org/images/{distro}/{distro}.yaml".format(**kwargs)
+        )
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            pass
+    with target_file.with_suffix(".yaml").open("wb") as fd:
+        fd.write(r.read())
+    logger.info("Image {distro} is ready!".format(**kwargs))

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -31,6 +31,18 @@ symbols = get_symbols()
 MB = 1024 * 1000
 
 
+class VMNotFound(Exception):
+    pass
+
+
+class ImageNotFoundUpstream(Exception):
+    pass
+
+
+class ImageNotFoundLocally(Exception):
+    pass
+
+
 def _register_aio_virt_impl(loop):
     # Ensure we may call shell.up() multiple times
     # from the same asyncio program.
@@ -54,7 +66,7 @@ def _start_domain(hv, host, context, configuration):
         logger.info(
             "Please select on of the following distro: %s", hv.distro_available()
         )
-        exit()
+        raise ImageNotFoundLocally()
 
     if "name" not in host:
         host["name"] = re.sub(r"[^a-zA-Z0-9-]+", "", host["distro"])
@@ -218,7 +230,7 @@ def stop(configuration, **kwargs):
             logger.info("No VM called %s in: %s", kwargs["name"], ", ".join(vm_list))
         else:
             logger.info("No running VM.")
-        exit(1)
+        raise VMNotFound()
     hv.clean_up(domain)
 
 
@@ -401,10 +413,10 @@ def fetch(configuration, progress_callback=None, **kwargs):
                 kwargs["distro"],
             )
 
-            sys.exit(1)
+            raise ImageNotFoundUpstream()
         else:
             logger.exception(e)
-            sys.exit(1)
+            raise
     lenght = int(r.headers["Content-Length"])
     chunk_size = MB * 1
     target_file = pathlib.PosixPath(

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -129,7 +129,7 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
     conn = libvirt.open(configuration.libvirt_uri)
     hv = vl.LibvirtHypervisor(conn)
 
-    conn.setKeepAlive(5, 3)
+    conn.setKeepAlive(interval=5, count=3)
     conn.domainEventRegisterAny(
         None, libvirt.VIR_DOMAIN_EVENT_ID_AGENT_LIFECYCLE, _lifecycle_callback, None,
     )

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import collections
 from concurrent.futures import ThreadPoolExecutor
 import logging
 
@@ -239,14 +240,12 @@ def ansible_inventory(configuration, context="default", **kwargs):
     )
 
     output = ""
-    groups = {}
+    groups = collections.defaultdict(list)
     for domain in hv.list_domains():
         if domain.context != context:
             continue
 
         for group in domain.groups:
-            if group not in groups:
-                groups[group] = []
             groups[group].append(domain)
 
         template = ssh_cmd_template

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -159,6 +159,8 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
         await asyncio.gather(*domain_reachable_futures)
 
     loop.run_until_complete(deploy())
+    if not kwargs.get("loop"):
+        loop.close()
     logger.info("%s You are all set", symbols.THUMBS_UP.value)
 
 
@@ -177,7 +179,7 @@ def start(configuration, context="default", enable_console=False, **kwargs):
     if not domain:
         return
 
-    loop = asyncio.get_event_loop()
+    loop = kwargs.get("loop") or asyncio.get_event_loop()
 
     if enable_console:
         import time
@@ -201,6 +203,8 @@ def start(configuration, context="default", enable_console=False, **kwargs):
         await domain.reachable()
 
     loop.run_until_complete(deploy())
+    if not kwargs.get("loop"):
+        loop.close()
     logger.info(  # noqa: T001
         (
             "\033[0m\n**** System is online ****\n"

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -97,7 +97,7 @@ def _start_domain(hv, host, context, configuration):
         network["mac"] = hv.reuse_mac_address(
             network["network"], host["name"], network.get("ipv4")
         )
-        domain.attachNetwork(**network)
+        domain.attach_network(**network)
     hv.start(domain, metadata_format=host.get("metadata_format", {}))
     return domain
 
@@ -107,7 +107,7 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
     Create a list of VM
     """
 
-    def myDomainEventAgentLifecycleCallback(conn, dom, state, reason, opaque):
+    def _lifecycle_callback(conn, dom, state, reason, opaque):  # noqa: N802
         if state == 1:
             logger.info("%s %s QEMU agent found", symbols.CUSTOMS.value, dom.name())
 
@@ -119,10 +119,7 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
 
     conn.setKeepAlive(5, 3)
     conn.domainEventRegisterAny(
-        None,
-        libvirt.VIR_DOMAIN_EVENT_ID_AGENT_LIFECYCLE,
-        myDomainEventAgentLifecycleCallback,
-        None,
+        None, libvirt.VIR_DOMAIN_EVENT_ID_AGENT_LIFECYCLE, _lifecycle_callback, None,
     )
 
     hv.init_network(configuration.network_name, configuration.network_cidr)

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -310,11 +310,14 @@ Example:
             )
             print(line, end="")  # noqa: T001
 
-        virt_lightning.api.fetch(
-            configuration=configuration,
-            progress_callback=progress_callback,
-            **vars(args)
-        )
+        try:
+            virt_lightning.api.fetch(
+                configuration=configuration,
+                progress_callback=progress_callback,
+                **vars(args)
+            )
+        except virt_lightning.api.ImageNotFoundUpstream:
+            exit(1)
     else:
         action_func = getattr(virt_lightning.api, args.action)
         action_func(configuration=configuration, **vars(args))

--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import typing
 import uuid
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # noqa: N817
 
 import libvirt
 
@@ -429,7 +429,7 @@ class LibvirtHypervisor:
         else:  # OpenStack format is the default
             cloud_init_iso = self.prepare_cloud_init_openstack_iso(domain)
 
-        domain.attachDisk(cloud_init_iso, device="cdrom", disk_type="raw")
+        domain.attach_disk(cloud_init_iso, device="cdrom", disk_type="raw")
         domain.dom.create()
         self.remove_domain_from_network(domain)
         self.add_domain_to_network(domain)
@@ -795,7 +795,7 @@ class LibvirtDomain:
         )
         self.dom.setMemoryFlags(value, libvirt.VIR_DOMAIN_AFFECT_CONFIG)
 
-    def getNextBlckDevice(self):
+    def get_next_block_device(self):
         if not hasattr(self, "blockdev"):
             self.blockdev = list(string.ascii_lowercase)
             self.blockdev.reverse()
@@ -840,14 +840,14 @@ class LibvirtDomain:
     def groups(self, value):
         self.record_metadata("groups", ",".join(value))
 
-    def attachDisk(self, volume, device="disk", disk_type="qcow2"):
+    def attach_disk(self, volume, device="disk", disk_type="qcow2"):
         if device == "cdrom":
             bus = "ide"
         elif self.distro.startswith("esxi"):
             bus = "sata"
         else:
             bus = "virtio"
-        device_name = self.getNextBlckDevice()
+        device_name = self.get_next_block_device()
         disk_root = ET.fromstring(DISK_XML)
         disk_root.attrib["device"] = device
         disk_root.findall("./driver")[0].attrib = {"name": "qemu", "type": disk_type}
@@ -857,7 +857,7 @@ class LibvirtDomain:
         self.dom.attachDeviceFlags(xml, libvirt.VIR_DOMAIN_AFFECT_CONFIG)
         return device_name
 
-    def attachNetwork(self, network=None, nic_model=None, ipv4=None, mac=None):
+    def attach_network(self, network=None, nic_model=None, ipv4=None, mac=None):
         if not nic_model:
             nic_model = self.default_nic_model
         net_root = ET.fromstring(BRIDGE_XML)
@@ -891,7 +891,7 @@ class LibvirtDomain:
             self.nics[i]["mac"] = iface.attrib["address"]
 
     def add_root_disk(self, root_disk_path):
-        self.attachDisk(root_disk_path)
+        self.attach_disk(root_disk_path)
 
     @property
     def ipv4(self):


### PR DESCRIPTION
Split up the content of `shell.py` in two parts.

- `api.py`: a generic module than can be reused by anyone
- `shell.py`: a CLI that consume `api.py`.