### PR TITLE
CentOS7: improve ssh performances

### DIFF
--- a/images/distros/centos-7
+++ b/images/distros/centos-7
@@ -1,8 +1,10 @@
-
 DOWNLOAD_URL=${MIRROR_URL:-https://cloud.centos.org}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
 IMAGE_NAME=centos-7
 
 function prepare {
     # https://bugs.centos.org/view.php?id=15426
-    virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 --run-command 'echo "" > /etc/resolv.conf' --selinux-relabel
+    virt-sysprep -a ${UPSTREAM_IMAGE_DIR}/${IMAGE_NAME}.qcow2 \
+        --run-command 'echo "" > /etc/resolv.conf' \
+        --run-command 'echo "UseDNS no" >> /etc/ssh/sshd_config' \
+        --selinux-relabel
 }


### PR DESCRIPTION
Small change in the guest sshd config. I noticed ssh timeouts when trying ansible-playbooks, this config change fixed that issue (and is recommended for guest instances, no clue why it's not by default yet for cloud images)