### PR TITLE
test: mock hv.get_qcow_virtual_size()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def hv(scope="function"):
     with patch.object(pathlib.Path, 'exists') as mock_exists:
         mock_exists.return_value = False
         hv.init_storage_pool("foo_bar")
+    hv.get_qcow_virtual_size = Mock(return_value=2)
     hv.init_network("my_network", "1.0.0.0/24")
     yield hv
     clean_up()


### PR DESCRIPTION
This to avoid the qemu-img call.