### PR TITLE
distro displayed in vl status output

### DIFF
--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -356,6 +356,7 @@ def status(configuration, context="default", name=None, **kwargs):
             "ipv4": domain.ipv4 and str(domain.ipv4.ip),
             "context": domain.context,
             "username": domain.username,
+            "distro": domain.distro
         }
 
 

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -356,7 +356,7 @@ def status(configuration, context="default", name=None, **kwargs):
             "ipv4": domain.ipv4 and str(domain.ipv4.ip),
             "context": domain.context,
             "username": domain.username,
-            "distro": domain.distro
+            "distro": domain.distro,
         }
 
 

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -272,10 +272,12 @@ Example:
                 "ipv4": status["ipv4"] or "waiting",
                 "context": status["context"],
                 "username": status["username"],
-                "distro": status["distro"]
+                "distro": status["distro"],
             }
 
-        output_template = "{computer} {name:<13}   {arrow}   {username}@{ipv4:>5} [{distro}]"
+        output_template = (
+            "{computer} {name:<13}   {arrow}   {username}@{ipv4:>5} [{distro}]"
+        )
         for _, v in sorted(results.items()):
             print(  # noqa: T001
                 output_template.format(

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -272,9 +272,10 @@ Example:
                 "ipv4": status["ipv4"] or "waiting",
                 "context": status["context"],
                 "username": status["username"],
+                "distro": status["distro"]
             }
 
-        output_template = "{computer} {name:<13}   {arrow}   {username}@{ipv4:>5}"
+        output_template = "{computer} {name:<13}   {arrow}   {username}@{ipv4:>5} [{distro}]"
         for _, v in sorted(results.items()):
             print(  # noqa: T001
                 output_template.format(


### PR DESCRIPTION
When running ``vl status``, new output should look like this 

```
💻 datastore       ⇛   centos@192.168.123.4 [centos-7]
💻 esxi1           ⇛   root@192.168.123.6 [esxi-6.7.0-20190802001-STANDARD]
💻 tst0            ⇛   username@192.168.123.5 [fedora-33]
💻 vcenter         ⇛   root@192.168.123.8 [VMware-VCSA-all-7.0.2-17694817]
```