### PR TITLE
[doc] Fix a typo: use 'vl' instead of 'vm' & add link to https://virt-lightning.org/

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ source ~/.bashrc
 # Fetch some images
 
 Before you start your first VM, you need to fetch the images. To do so,
-you just use the `vm fetch` command:
+you just use the `vl fetch` command:
 
 ```shell
 $ vl fetch fedora-32

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://travis-ci.org/virt-lightning/virt-lightning.svg?branch=master)](https://travis-ci.org/virt-lightning/virt-lightning)
 [![PyPI version](https://badge.fury.io/py/virt-lightning.svg)](https://badge.fury.io/py/virt-lightning)
+[![Documentation](https://shields.io/static/v1?message=Documentation&color=blue)](https://virt-lightning.org/)
 
 ![Logo](https://github.com/virt-lightning/virt-lightning/raw/master/logo/logo_no_text.png)
 


### PR DESCRIPTION
doc:
* Fix a typo: use `vl` instead of `vm`.
* add a link to `https://virt-lightning.org/`