### PR TITLE
vl stop: no backtrace if VM does not exist

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -376,6 +376,8 @@ Example:
         try:
             action_func = getattr(virt_lightning.api, args.action)
             action_func(configuration=configuration, **vars(args))
+        except virt_lightning.api.VMNotFound as e:
+            pass
         except virt_lightning.api.ImageNotFoundLocally as e:
             print(  # noqa: T001
                 (


### PR DESCRIPTION
Do not raise a backtrace if a VM does not exist.

Closes: #212