### PR TITLE
up: reopen the libvirt connection after download

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 2.1.1
+
+- reconnect to libvirt after the download step (#218)
+
 # 2.1.0
 
 - distro displayed in vl status output (#199)

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -170,6 +170,11 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
     conn = _connect_libvirt(configuration.libvirt_uri)
     hv = vl.LibvirtHypervisor(conn)
 
+    hv.init_network(configuration.network_name, configuration.network_cidr)
+    hv.init_storage_pool(configuration.storage_pool)
+
+    _ensure_image_exists(hv, virt_lightning_yaml)
+    conn = _connect_libvirt(configuration.libvirt_uri)
     conn.setKeepAlive(interval=5, count=3)
     conn.domainEventRegisterAny(
         None,
@@ -178,10 +183,6 @@ def up(virt_lightning_yaml, configuration, context="default", **kwargs):
         None,
     )
 
-    hv.init_network(configuration.network_name, configuration.network_cidr)
-    hv.init_storage_pool(configuration.storage_pool)
-
-    _ensure_image_exists(hv, virt_lightning_yaml)
     pool = ThreadPoolExecutor(max_workers=10)
 
     async def deploy():


### PR DESCRIPTION
The download can take a bit of time. Because of that, the libvirt
connection may be lost. We now reconnect after this step.

Closes: https://github.com/virt-lightning/virt-lightning/issues/218
