### PR TITLE
add support for legacy system without virtio

### DIFF
--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -118,6 +118,8 @@ def _start_domain(hv, host, context, configuration):
         "default_nic_mode": host.get("default_nic_model"),
         "bootcmd": host.get("bootcmd"),
         "runcmd": host.get("runcmd"),
+        "meta_data_media_type": host.get("meta_data_media_type"),
+        "default_bus_type": host.get("default_bus_type"),
     }
     domain = hv.create_domain(name=host["name"], distro=distro)
     hv.configure_domain(domain, user_config)


### PR DESCRIPTION
- new key `meta_data_media_type` to expose cloud-init meta data through
  a cdrom
- `default_bus_type` to switch between `ide`, `sata` and `virtio`.
