### PR TITLE
Set the Source project URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,7 @@ setuptools.setup(
         ]
     },
     setup_requires=["setuptools_scm"],
+    project_urls={
+        'Source': 'https://github.com/virt-lightning/virt-lightning',
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,6 @@ setuptools.setup(
     },
     setup_requires=["setuptools_scm"],
     project_urls={
-        'Source': 'https://github.com/virt-lightning/virt-lightning',
-    }
+        "Source": "https://github.com/virt-lightning/virt-lightning",
+    },
 )


### PR DESCRIPTION
I had a hard time to find the source. At first I read the website and then went to PyPI, but eventually I just searched using a search engine. This uses project_urls[1] in setup.py to add URLs on PyPI, which makes it easier to find the source.

[1]: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls