### PR TITLE
Change default "meta_data_media_type" to "cdrom"

### DIFF
--- a/virt_lightning/virt_lightning.py
+++ b/virt_lightning/virt_lightning.py
@@ -121,7 +121,7 @@ class LibvirtHypervisor:
             "default_nic_model": "virtio",
             "bootcmd": [],
             "runcmd": [],
-            "meta_data_media_type": "disk",
+            "meta_data_media_type": "cdrom",
             "default_bus_type": "virtio",
         }
         for k, v in self.get_distro_configuration(domain.distro).items():


### PR DESCRIPTION
Current setup blocks snapshot creation for running instance

Closes: #272