### PR TITLE
update debian images

### DIFF
--- a/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
+++ b/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
@@ -19,8 +19,9 @@ virt-lightning.org {
     # Debian
     redir /images/debian-9/debian-9.qcow2 https://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
     redir /images/debian-10/debian-10.qcow2 https://cdimage.debian.org/cdimage/openstack/current-10/debian-10-openstack-amd64.qcow2
-    redir /images/debian-testing/debian-testing.qcow2 https://cdimage.debian.org/cdimage/openstack/testing/debian-testing-openstack-amd64.qcow2
     redir /images/debian-11/debian-11.qcow2 https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-generic-amd64.qcow2
+    redir /images/debian-12/debian-12.qcow2 https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-generic-amd64.qcow2
+    redir /images/debian-sid/debian-sid.qcow2 https://cdimage.debian.org/cdimage/cloud/sid/daily/latest/debian-sid-generic-amd64-daily.qcow2
 
 
 

--- a/virt-lightning.org/www/images/index.md
+++ b/virt-lightning.org/www/images/index.md
@@ -9,8 +9,9 @@
 - centos-9-stream
 - debian-9
 - debian-10
-- debian-testing
 - debian-11
+- debian-12
+- debian-sid
 - dragonflybsd-5.6.3
 - dragonflybsd-5.8.3
 - dragonflybsd-6.0.0-ufs


### PR DESCRIPTION
remove debian-testing image, link nolonger exists, and was based on debian-10

add debian-12 image
add debian-sid

cannot find current debian-testing/debian-13/debian-trixie image