### PR TITLE
Update Readme installation instructions for Debian to use pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,32 @@ During this recording, we:
 
 [![demo](https://asciinema.org/a/230671.svg)](https://asciinema.org/a/230671?autoplay=1)
 
-## Pre-requirements
 
-- Python 3.8 or greater.
-- The Python3 binding for libvirt, the package is probably called `python3-libvirt`.
-- You can also just build the binding during the install, in this case, you will need to install some packages first:
-    - `dnf install libvirt-devel python3-devel` (Fedora/RHEL)
-    - `apt install libvirt-dev python3-dev` (Debian/Ubuntu)
-- You make also want to install `python3-urwid` if you want to get the fancy list of VM. This dependency is optional.
+## Requirements
+- Python 3.8 or greater
+- The Python3 binding for libvirt, the package is probably called `python3-libvirt` or 'libvirt-python' according to pip.
 - Libvirt must be running, most of the time you just need to run: `sudo systemctl start --now libvirtd`
 - Finally, be sure your user can access the system libvirt daemon, e.g with: `virsh -c qemu:///system`
 
-## Installation
+## Optional
+- You make also want to install `python3-urwid` if you want to get the fancy list of VM. This dependency is optional.
 
+
+## Installation (Fedora/RHEL)
 ```shell
-pip3 install --user virt-lightning
+sudo dnf install libvirt-devel gcc python3-devel pipx
+pipx ensurepath
+pipx install virt-lightning
 ```
 
-If you use Ubuntu, you will need the `--no-deps` argument (See: https://github.com/pypa/pip/issues/4222).
+## Installation (Debian/Ubuntu)
+```shell
+sudo apt install python3-venv pkg-config gcc libvirt-dev python3-dev pipx
+pipx ensurepath
+pipx install virt-lightning
+```
+
+## Post Installation
 
 `virt-lightning` will be installed in ~/.local/bin/. Add it in your `$PATH` if
 it's not already the case. For instance if you use:
@@ -251,13 +259,13 @@ virsh snapshot-list vm_name
 # and revert to the first one
 virsh snapshot-revert vm_name --snapshotname snapshot_1
 ```
-=======
+
 ### Development
 install libvirt-dev package:
 
 Debian/Ubuntu:
 ```shell
-apt-get install python3-venv python3-dev pkg-config gcc libvirt-dev
+apt install python3-venv pkg-config gcc libvirt-dev python3-dev
 ```
 
 Fedora/RHEL:


### PR DESCRIPTION
Closes #281 

pipx appears to seamlessly wrap up isolated python application.  feels a bit odd for a user install to require more packages (pipx) than a development setup but....

Figured differences were enough to break install into portions for REHL/Fedora and Debian/Ubuntu.
Changed an instance of apt-get to apt
removed merge conflict marker I stumbled across

Of note, pip3 install virt-lightning --break-system-packages is ~450 Mb clean to installed while pipx and build environment is ~850 Mb clean to installed, that kinda bothered me, but then I figured nobody is running this on a clean system, and if they are, they'll eventually want gcc and additional build utils right?

Tested on Ubuntu 23.10 VM's
Memory usage from : /usr/bin/time -v vl up ~ 60mb
Storage usage from : du -ah -d 1 /var/lib/virt-lightning/pool/
