### PR TITLE
Remove and replace distutils.util.strtobool

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,76 @@
+import pytest
+
+from virt_lightning.util import strtobool
+
+
+@pytest.mark.parametrize(
+    "str_value,expected",
+    [
+        ("t", True),
+        ("T", True),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("y", True),
+        ("Y", True),
+        ("yes", True),
+        ("Yes", True),
+        ("YES", True),
+        ("1", True),
+        ("f", False),
+        ("F", False),
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("n", False),
+        ("N", False),
+        ("no", False),
+        ("No", False),
+        ("NO", False),
+        ("0", False),
+        (" f ", False),
+        ("  f  ", False),
+        (" f\t", False),
+        (" f\n", False),
+        (" f\r\n", False),
+        ("f\r\n", False),
+        ("\tf\r\n", False),
+    ],
+)
+def test_strtobool(str_value: str, expected: bool):
+    assert strtobool(str_value) == expected
+
+@pytest.mark.parametrize(
+    "str_value",
+    [
+        "",
+        " ",
+        "\n",
+        "\r\n",
+        "\t",
+        "some-other-value",
+        "a",
+    ],
+)
+def test_strtobool__value_error(str_value: str):
+    with pytest.raises(ValueError):
+        strtobool(str_value)
+
+@pytest.mark.parametrize(
+    "str_value",
+    [
+        None,
+        123,
+        3.5,
+        [],
+        ["t"],
+        ["t", "f"],
+        {},
+        {"t": "f"},
+        ((),),
+        (("t"),),
+    ],
+)
+def test_strtobool__type_error(str_value: str):
+    with pytest.raises(TypeError):
+        strtobool(str_value)

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import collections
-import distutils.util
 import ipaddress
 import logging
 import pathlib
@@ -16,6 +15,7 @@ import libvirt
 import virt_lightning.virt_lightning as vl
 from virt_lightning.configuration import Configuration
 from virt_lightning.symbols import get_symbols
+from virt_lightning.util import strtobool
 
 BASE_URL = "https://virt-lightning.org"
 
@@ -420,7 +420,7 @@ def down(configuration, context="default", **kwargs):
         logger.info("%s purging %s", symbols.TRASHBIN.value, domain.name)
         hv.clean_up(domain)
 
-    if bool(distutils.util.strtobool(configuration.network_auto_clean_up)):
+    if strtobool(configuration.network_auto_clean_up):
         hv.network_obj.destroy()
 
 

--- a/virt_lightning/util.py
+++ b/virt_lightning/util.py
@@ -1,0 +1,22 @@
+def strtobool(value: str) -> bool:
+    """Convert a range of string representations of a boolean to bool. Case insensitive.
+
+    String values converted to;
+
+    bool[True]: ('t', 'true', 'y', 'yes', '1')
+    bool[False]: ('f', 'false', 'n', 'no', '0')
+
+    Raises TypeError in case of non-string type and ValueError when provided an invalid
+    input.
+
+    """
+    if not isinstance(value, str):
+        raise TypeError(f"{type(value)} cannot be converted to boolean")
+
+    p_value = value.strip("\n\r\t ").lower()
+    if p_value in ("t", "true", "y", "yes", "1"):
+        return True
+    elif p_value in ("f", "false", "n", "no", "0"):
+        return False
+    else:
+        raise ValueError(f"Cannot convert to boolean {value!r}")


### PR DESCRIPTION
Replaces `distutils.util.strtobool` with a utility for Python 3.12 compatibility.