### PR TITLE
ruff: use f-string to format the fetch progress bar

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,6 +40,7 @@ from virt_lightning.util import strtobool
 def test_strtobool(str_value: str, expected: bool):
     assert strtobool(str_value) == expected
 
+
 @pytest.mark.parametrize(
     "str_value",
     [
@@ -55,6 +56,7 @@ def test_strtobool(str_value: str, expected: bool):
 def test_strtobool__value_error(str_value: str):
     with pytest.raises(ValueError):
         strtobool(str_value)
+
 
 @pytest.mark.parametrize(
     "str_value",

--- a/virt-lightning.org/bench_images_startup.py
+++ b/virt-lightning.org/bench_images_startup.py
@@ -48,6 +48,4 @@ for distro in distros:
         elapsed_time = time.time() - start_time
         sum += elapsed_time
         print(f"- elapsed_time={elapsed_time:06.2f}")
-    print(
-        f"FINAL distro={distro}: {sum / number_of_runs}"
-    )
+    print(f"FINAL distro={distro}: {sum / number_of_runs}")

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -102,11 +102,9 @@ def viewer(configuration, name=None, **kwargs):
 
 def progress_callback(cur, length):
     percent = (cur * 100) / length
-    line = "🌍 ➡️  💻 [{percent:06.2f}%]  {done:6}MB/{full}MB\r".format(
-        percent=percent,
-        done=int(cur / virt_lightning.api.MB),
-        full=int(length / virt_lightning.api.MB),
-    )
+    done = int(cur / virt_lightning.api.MB)
+    full = int(length / virt_lightning.api.MB)
+    line = f"🌍 ➡️  💻 [{percent:06.2f}%]  {done:6}MB/{full}MB\r"
     print(line, end="")  # noqa: T001
 
 


### PR DESCRIPTION
This to address the following `ruff` error:

```
virt_lightning/shell.py:105:12: UP032 [*] Use f-string instead of `format` call
```

and a problem with up-to-date `black`.