### PR TITLE
centos-n-stream renamed to centos-stream-n

### DIFF
--- a/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
+++ b/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
@@ -30,6 +30,8 @@ virt-lightning.org {
     redir /images/centos-7/centos-7.qcow2 http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
     redir /images/centos-6/centos-6.qcow2 https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2
     redir /images/centos-8/centos-8.qcow2 https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
+    redir /images/centos-stream-8/centos-stream-8.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
+    redir /images/centos-stream-9/centos-stream-9.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
     redir /images/centos-8-stream/centos-stream-8.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
     redir /images/centos-9-stream/centos-stream-9.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
 

--- a/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
+++ b/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
@@ -30,10 +30,10 @@ virt-lightning.org {
     redir /images/centos-7/centos-7.qcow2 http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
     redir /images/centos-6/centos-6.qcow2 https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2
     redir /images/centos-8/centos-8.qcow2 https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
+    redir /images/centos-8-stream/centos-8-stream.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
+    redir /images/centos-9-stream/centos-9-stream.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
     redir /images/centos-stream-8/centos-stream-8.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
     redir /images/centos-stream-9/centos-stream-9.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
-    redir /images/centos-8-stream/centos-stream-8.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
-    redir /images/centos-9-stream/centos-stream-9.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
 
     # AlmaLinux
     redir /images/almalinux-8/almalinux-8.qcow2 https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2

--- a/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
+++ b/virt-lightning.org/etc/caddy/conf.d/virt-lightning.org.conf
@@ -30,8 +30,8 @@ virt-lightning.org {
     redir /images/centos-7/centos-7.qcow2 http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
     redir /images/centos-6/centos-6.qcow2 https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2
     redir /images/centos-8/centos-8.qcow2 https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
-    redir /images/centos-8-stream/centos-8-stream.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
-    redir /images/centos-9-stream/centos-9-stream.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
+    redir /images/centos-8-stream/centos-stream-8.qcow2 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2
+    redir /images/centos-9-stream/centos-stream-9.qcow2 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
 
     # AlmaLinux
     redir /images/almalinux-8/almalinux-8.qcow2 https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2

--- a/virt-lightning.org/www/images/index.md
+++ b/virt-lightning.org/www/images/index.md
@@ -5,8 +5,8 @@
 - centos-6
 - centos-7
 - centos-8
-- centos-8-stream
-- centos-9-stream
+- centos-stream-8
+- centos-stream-9
 - debian-9
 - debian-10
 - debian-11


### PR DESCRIPTION
The official name of CentOS is CentOS Stream now. This should be reflected in the name of the images, IMHO.

It reads better too, at least to me.

This one fixes issue #304