### PR TITLE
pyproject: update ruff configuration key names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = {file = ["requirements.txt"]}
 
 [tool.ruff]
 line-length = 100
-select = [
+lint.select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
 #    "D",  # pydocstyle
@@ -63,4 +63,4 @@ select = [
     "W",  # Warning
     "YTT", # flake8-2020
 ]
-ignore = ["N806"]
+lint.ignore = ["N806"]


### PR DESCRIPTION
This to address the following warning:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```
