### PR TITLE
Fix for inventory template

### DIFF
--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -323,7 +323,7 @@ def ansible_inventory(configuration, context="default", **kwargs):
             name=domain.name,
             username=domain.username,
             ipv4=domain.ipv4.ip,
-            additional_nics=domain.additional_nics,
+            additional_nics=domain.additional_nics or "",
             python_interpreter=domain.python_interpreter,
         )  # noqa: T001
 


### PR DESCRIPTION
Prevents inserting 'None' to inventory when additional NICs are not defined