### PR TITLE
refresh.py: Support overriding `python_interpreter` via `images_data.json`

### DIFF
--- a/virt-lightning.org/images.json
+++ b/virt-lightning.org/images.json
@@ -254,7 +254,9 @@
   {
     "name": "openbsd-7.6-ufs",
     "qcow2_url": "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.6_2024-10-08-22-40/openbsd-min.qcow2",
-    "meta": {},
+    "meta": {
+      "python_interpreter": "/usr/local/bin/python3"
+    },
     "yaml_url": ""
   },
   {

--- a/virt-lightning.org/refresh.py
+++ b/virt-lightning.org/refresh.py
@@ -106,10 +106,16 @@ def get_bsd_images() -> list[Image]:
     images: list[Image] = []
     for os in resp.json():
         for version in os["versions"]:
-            for image in version["images"]:
-                name = f"{os['name']}-{version['name']}-{image['flavor'].lower()}"
-                image = Image(name, image["url"])
+            for image_dict in version["images"]:
+                name = f"{os['name']}-{version['name']}-{image_dict['flavor'].lower()}"
+                image = Image(name, image_dict["url"])
                 image.retrieve_metadata()
+
+                python_interpreter = image_dict.get("python_interpreter")
+
+                if python_interpreter:
+                    image.meta["python_interpreter"] = python_interpreter
+
                 images.append(image)
     return images
 


### PR DESCRIPTION
Without this, I get a `/bin/sh: /usr/bin/python3: not found` error when trying to run Ansible towards an OpenBSD 7.6 machine created using this tool. Overriding it in the inventory to use this path makes it work.