### PR TITLE
fetch: don't use virt-lightning.org anymore

### DIFF
--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -370,7 +370,7 @@ Commands:
         except virt_lightning.api.ImageNotFoundUpstreamError:
             print(  # noqa: T001
                 f"Distro {args.distro} cannot be downloaded.\n"
-                f"  Visit {virt_lightning.api.BASE_URL}/images/ or private image hub"
+                f"  Visit {virt_lightning.api.BASE_URL}/images/ or private image hub "
                 "to get an up to date list."
             )
             exit(1)


### PR DESCRIPTION
Replace the use of the Caddy service hosted at http://virt-lightning.org
with the `images.json` file introduced by 6e4fbb099d02b20ad61288789a16aa979386cfc6.
