### PR TITLE
SSH key: dynamic file lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ A VM can be tuned at two different places with the following keys:
 - `memory`: the amount of memory to dedicate to the VM
 - `vcpus`: the number of vcpu to dedicate to the VM
 - `root_password`: the root password in clear text
-- `ssh_key_file`: the path of the public key for connecting to the VM
+- `ssh_key_file`: the path of the public key for connecting to the VM. If the value, Virt-Lightning will pick the first key matching `~/.ssh/id_*.pub`.
 - `groups`: this list of groups will be used if you generate an Ansible inventory.
 - `disks`: a list of disks to create and attach to the VM. The first one is used as the root disk. Default to `[{"size": 15}]`
     - `size` the size of the disk in GB. Default is `1`.

--- a/virt_lightning/configuration.py
+++ b/virt_lightning/configuration.py
@@ -1,8 +1,11 @@
 import configparser
+import logging
 from abc import ABCMeta, abstractproperty
-from pathlib import PosixPath
+from pathlib import Path
 
-DEFAULT_CONFIGFILE = PosixPath("~/.config/virt-lightning/config.ini")
+logger = logging.getLogger("virt_lightning")
+
+DEFAULT_CONFIGFILE = Path("~/.config/virt-lightning/config.ini")
 
 
 DEFAULT_CONFIGURATION = {
@@ -13,7 +16,7 @@ DEFAULT_CONFIGURATION = {
         "network_name": "virt-lightning",
         "network_cidr": "192.168.123.0/24",
         "network_auto_clean_up": True,
-        "ssh_key_file": "~/.ssh/id_rsa.pub",
+        "ssh_key_file": "",
         "private_hub": "",
         "custom_image_list": "",
     }
@@ -91,7 +94,13 @@ class Configuration(AbstractConfiguration):
 
     @property
     def ssh_key_file(self):
-        return self.__get("ssh_key_file")
+        if self.__get("ssh_key_file"):
+            return self.__get("ssh_key_file")
+
+        found = next((Path.home() / ".ssh").glob("id_*.pub"), None)
+        logger.debug(f"No SSH key defined in configuration, failing back on {found}")
+
+        return found
 
     @property
     def storage_pool(self):


### PR DESCRIPTION
When `ssh_key_file` is empty, we now do a dynamic look up all the good
SSH key candidate in `~/.ssh/`.

Close: #320
