### PR TITLE
add support for a user defined image list

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ ssh_key_file = ~/.ssh/id_rsa.pub
 private_hub=url1,url2
 ```
 
+**custom_image_list**: if you wish to use a custom image list, update the configuration file `~/.config/virt-lightning/config.ini` adding the following
+```
+[main]
+custom_image_url=<url>/images.json
+```
+take a look at [images.json](virt-lightning.org/images.json) for a reference
+
 ## VM configuration keys
 
 A VM can be tuned at two different places with the following keys:

--- a/virt_lightning/api.py
+++ b/virt_lightning/api.py
@@ -486,18 +486,17 @@ def fetch_from_url(progress_callback=None, url=None, **kwargs):
     logger.info(f"Image {kwargs['distro']} is ready!")
 
 
-def get_image_index():
-    f = urllib.request.urlopen(
-        "https://raw.githubusercontent.com/virt-lightning/virt-lightning/refs/heads/main/virt-lightning.org/images.json"
-    )
+def get_image_index(configuration):
+    index_url = configuration.custom_image_list or "https://raw.githubusercontent.com/virt-lightning/virt-lightning/refs/heads/main/virt-lightning.org/images.json"
+    f = urllib.request.urlopen(index_url)
     return json.loads(f.read())
 
 
-def fetch_distro(progress_callback=None, url=None, **kwargs):
+def fetch_distro(configuration, progress_callback=None, url=None, **kwargs):
     """Retrieve a VM image from a given url
     - when url is set to None, this means we are trying to fetch from the default url.
     """
-    image_index = get_image_index()
+    image_index = get_image_index(configuration)
     try:
         image_info = [i for i in image_index if i["name"] == kwargs["distro"]][0]
     except (IndexError, KeyError):
@@ -569,6 +568,7 @@ def fetch(configuration=None, progress_callback=None, hv=None, **kwargs):
             )
 
     fetch_distro(
+        configuration=configuration,
         progress_callback=progress_callback,
         storage_dir=hv.get_storage_dir(),
         **kwargs,

--- a/virt_lightning/configuration.py
+++ b/virt_lightning/configuration.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIGURATION = {
         "network_auto_clean_up": True,
         "ssh_key_file": "~/.ssh/id_rsa.pub",
         "private_hub": "",
+        "custom_image_list": "",
     }
 }
 
@@ -46,6 +47,10 @@ class AbstractConfiguration(metaclass=ABCMeta):
 
     @abstractproperty
     def storage_pool(self):
+        pass
+
+    @abstractproperty
+    def custom_image_list(self):
         pass
 
     def __repr__(self):
@@ -95,6 +100,10 @@ class Configuration(AbstractConfiguration):
     @property
     def private_hub(self):
         return [x for x in self.__get("private_hub").split(",") if x != ""]
+
+    @property
+    def custom_image_list(self):
+        return self.__get("custom_image_list")
 
     def load_file(self, config_file):
         self.data.read_string(config_file.read_text())

--- a/virt_lightning/shell.py
+++ b/virt_lightning/shell.py
@@ -370,7 +370,7 @@ Commands:
         except virt_lightning.api.ImageNotFoundUpstreamError:
             print(  # noqa: T001
                 f"Distro {args.distro} cannot be downloaded.\n"
-                f"  Visit {virt_lightning.api.BASE_URL}/images/ or private image hub "
+                f"  Visit {virt_lightning.api.BASE_URL}/images/ or add a custom image list / private image hub "
                 "to get an up to date list."
             )
             exit(1)


### PR DESCRIPTION
added support for a user defined json url, for cases where the needed distribution is not in the official json and a custom image repository is not necessary.


- to use add a custom_image_url in virt-lightning config