### PR TITLE
Deprecated locale detection updated

### DIFF
--- a/virt_lightning/symbols.py
+++ b/virt_lightning/symbols.py
@@ -1,4 +1,4 @@
-import locale
+import sys
 from enum import Enum, unique
 
 
@@ -28,8 +28,10 @@ class SymbolsDefault(Enum):
 
 
 def get_symbols():
-    _, encoding = locale.getlocale()
-
-    if encoding and encoding.upper() == "UTF-8":
-        return SymbolsUTF
+    try:
+        if sys.stdout.encoding and sys.stdout.encoding.lower() == "utf-8":
+            return SymbolsUTF
+    except AttributeError:
+        # To handle cases where sys.stdout.encoding is None, like > /dev/null
+        pass
     return SymbolsDefault

--- a/virt_lightning/symbols.py
+++ b/virt_lightning/symbols.py
@@ -28,8 +28,8 @@ class SymbolsDefault(Enum):
 
 
 def get_symbols():
-    lang, encoding = locale.getdefaultlocale()
+    _, encoding = locale.getlocale()
 
-    if encoding and encoding == "UTF-8":
+    if encoding and encoding.upper() == "UTF-8":
         return SymbolsUTF
     return SymbolsDefault


### PR DESCRIPTION
Tried to keep compatibility with pre-3.11 Python. Does not ensure that locale was set up, so might fall back to ASCII depending on system-wide and shell configuration